### PR TITLE
fix: http server preventing exit

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -41,8 +41,8 @@
             .hash = "zig_yaml-0.1.0-C1161piWAgDpeXlIH32h9rEXCzWyjGx0ypxR0XwdAf6Q",
         },
         .libxev = .{
-            .url = "https://github.com/mitchellh/libxev/archive/5647630d7bff969414a0edc24c03c30aff34b101.tar.gz",
-            .hash = "libxev-0.0.0-86vtc4b1EgCl0Kvo2Ixmjfl5PgAaJmvCXRIn_n89nCaR",
+            .url = "https://github.com/mitchellh/libxev/archive/75a10d0fb374e8eb84948dcfc68d865e755e59c2.tar.gz",
+            .hash = "libxev-0.0.0-86vtcyMBEwA-UpcjfOICyI2GYG8o6MiRbinS1_8g1_rw",
         },
         .smtp_client = .{
             .url = "https://github.com/karlseguin/smtp_client.zig/archive/79cd8d0500f1df16aaa1f018011615a132c309e6.tar.gz",

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
                   pname
                   version
                   ;
-                hash = "sha256-VbVHoyCHxLFlETbvMo+rSL8INI0e27BOQuyv2Zq4CkA=";
+                hash = "sha256-z3h4bvYX40nVRgzU3jZ2Vw92Y87eDXqdEvNgLJwPM1s=";
               };
 
               postUnpack = ''

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -14,16 +14,6 @@ pub const Smtp = struct {
     message_id_host: ?[]const u8 = null,
     address: ?[]const u8 = null,
 
-    pub fn deinit(self: *Smtp, alloc: std.mem.Allocator) void {
-        alloc.free(self.host);
-
-        if (self.username) |username| alloc.free(username);
-        if (self.password) |password| alloc.free(password);
-        if (self.local_name) |local_name| alloc.free(local_name);
-        if (self.message_id_host) |message_id_host| alloc.free(message_id_host);
-        if (self.address) |address| alloc.free(address);
-    }
-
     pub fn toSmtpClientConfig(self: *const Smtp, alloc: std.mem.Allocator) smtp_client.Config {
         return .{
             .port = self.port orelse 25,
@@ -45,12 +35,6 @@ pub const Ollama = struct {
     port: ?u16,
     default_model: ?[]const u8,
 
-    pub fn deinit(self: *Ollama, alloc: std.mem.Allocator) void {
-        if (self.schema) |schema| alloc.free(schema);
-        if (self.host) |host| alloc.free(host);
-        if (self.default_model) |default_model| alloc.free(default_model);
-    }
-
     pub fn toOllama(self: *const Ollama, alloc: std.mem.Allocator) OllamaClient {
         return .{
             .allocator = alloc,
@@ -63,13 +47,6 @@ pub const Ollama = struct {
 
 pub const HttpServer = struct {
     address: ?[]const u8,
-
-    pub fn deinit(self: *HttpServer, alloc: std.mem.Allocator) void {
-        _ = self;
-        _ = alloc;
-        // FIXME: invalid free
-        //if (self.address) |addr| alloc.free(addr);
-    }
 
     pub fn getAddress(self: *const HttpServer) !std.net.Address {
         const addr = self.address orelse "localhost:8080";
@@ -98,9 +75,3 @@ pub const HttpServer = struct {
 smtp: ?Smtp = null,
 ollama: ?Ollama = null,
 http_server: ?HttpServer = null,
-
-pub fn deinit(self: *Self, alloc: std.mem.Allocator) void {
-    if (self.smtp) |*s| s.deinit(alloc);
-    if (self.ollama) |*ollama| ollama.deinit(alloc);
-    if (self.http_server) |*h| h.deinit(alloc);
-}

--- a/src/main.zig
+++ b/src/main.zig
@@ -57,7 +57,6 @@ pub fn main() !void {
     var once = false;
 
     var config: ?Config = null;
-    defer if (config) |*cfg| cfg.deinit(gpa);
 
     var workflow: ?Workflow = null;
     defer if (workflow) |*wf| wf.deinit(alloc);


### PR DESCRIPTION
When running in once mode, the workflow runner does not exit. This is because the server thread waits. However, we're still waiting for the socket to receive.